### PR TITLE
Water screen scale correction

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -43,6 +43,8 @@ extern FPSSetting gFPSSetting;
 int BetterSMS::getScreenRenderWidth() {
     switch (gAspectRatioSetting.getInt()) {
     default:
+    case AspectRatioSetting::FULLOPENMATTE:
+        return 600;
     case AspectRatioSetting::FULL:
         return 600;
     case AspectRatioSetting::WIDE:
@@ -54,6 +56,8 @@ int BetterSMS::getScreenRenderWidth() {
 int BetterSMS::getScreenOrthoWidth() {
     switch (gAspectRatioSetting.getInt()) {
     default:
+    case AspectRatioSetting::FULLOPENMATTE:
+        return 640;
     case AspectRatioSetting::FULL:
         return 640;
     case AspectRatioSetting::WIDE:

--- a/src/p_settings.hxx
+++ b/src/p_settings.hxx
@@ -822,16 +822,19 @@ private:
 
 class AspectRatioSetting final : public Settings::IntSetting {
 public:
-    enum Kind { FULL, WIDE, ULTRAWIDE };
+    enum Kind { FULLOPENMATTE, FULL, WIDE, ULTRAWIDE };
 
     AspectRatioSetting(const char *name) : IntSetting(name, &AspectRatioSetting::sAspectRatioValue) {
-        mValueRange     = {0, 2, 1};
+        mValueRange     = {0, 2, 1, 1};
     }
     ~AspectRatioSetting() override {}
 
     void getValueStr(char *dst) const override {
         switch (getInt()) {
         default:
+        case Kind::FULLOPENMATTE:
+            strncpy(dst, "4:3 (Open Matte)", 17);
+            break;
         case Kind::FULL:
             strncpy(dst, "4:3", 4);
             break;

--- a/src/p_settings.hxx
+++ b/src/p_settings.hxx
@@ -825,7 +825,7 @@ public:
     enum Kind { FULLOPENMATTE, FULL, WIDE, ULTRAWIDE };
 
     AspectRatioSetting(const char *name) : IntSetting(name, &AspectRatioSetting::sAspectRatioValue) {
-        mValueRange     = {0, 2, 1, 1};
+        mValueRange     = {0, 3, 1};
     }
     ~AspectRatioSetting() override {}
 

--- a/src/patches/widescreen.cpp
+++ b/src/patches/widescreen.cpp
@@ -1,6 +1,6 @@
 
 #include <Dolphin/types.h>
-
+#include <Dolphin/math.h>
 #include <JSystem/JUtility/JUTRect.hxx>
 #include <JSystem/JUtility/JUTTexture.hxx>
 #include <SMS/G2D/ExPane.hxx>
@@ -57,6 +57,8 @@ SMS_WRITE_32(SMS_PORT_REGION(0x80177008, 0x8016D174, 0, 0), 0xD03B0038);
 SMS_PATCH_BL(SMS_PORT_REGION(0x801771A8, 0x8016CFCC, 0, 0), getScreenWidthf);
 SMS_WRITE_32(SMS_PORT_REGION(0x801771AC, 0x8016CFD0, 0, 0), 0xD03B0038);
 
+extern AspectRatioSetting gAspectRatioSetting;
+
 static f32 getScreenXRatio2() {
     const f32 ratio = getScreenToFullScreenRatio();
     return ratio + (ratio - 1.0f);
@@ -65,6 +67,24 @@ static f32 getScreenXRatio2() {
 static f32 getShineSelectXRatio() { return getScreenXRatio2() * 1.33333337307; }
 
 static f32 getCameraXRatio() { return getScreenXRatio2() * 0.913461446762f; }
+
+static f32 getScreenScale() { return gAspectRatioSetting.getInt() == AspectRatioSetting::FULLOPENMATTE: ? 0.75f : 1.0f; }
+
+static f32 getRecalculatedFovyInc(f32 fov) { 
+    return 2.0f * atanf(tanf(fov * 0.5f) / getScreenScale()); 
+}
+
+static f32 getRecalculatedFovyDec(f32 fov) { 
+    return 2.0f * atanf(tanf(fov * 0.5f) * getScreenScale()); 
+}
+
+static f32 getRecalculatedFovyAngleInc(f32 fov) { 
+    return radiansToAngle(getRecalculatedFovyInc(angleToRadians(fov))); 
+}
+
+static f32 getRecalculatedFovyAngleDec(f32 fov) { 
+    return radiansToAngle(getRecalculatedFovyDec(angleToRadians(fov))); 
+}
 
 // Shine Select Model Rot Width
 SMS_PATCH_BL(SMS_PORT_REGION(0x80176E58, 0x8016CE20, 0, 0), getShineSelectXRatio);
@@ -80,6 +100,17 @@ SMS_WRITE_32(SMS_PORT_REGION(0x802B8B7C, 0x802B0B4C, 0, 0), 0x3C60803E);
 SMS_WRITE_32(SMS_PORT_REGION(0x802B8B88, 0x802B0B58, 0, 0), 0xC8010AE0);
 SMS_WRITE_32(SMS_PORT_REGION(0x802B8B94, 0x802B0B64, 0, 0), 0xEC001028);
 SMS_WRITE_32(SMS_PORT_REGION(0x802B8B9C, 0x802B0B6C, 0, 0), 0xEC010032);
+
+static void scaleFOVYPerspectiveMatrix(Mtx mtx, f32 fovY, f32 aspect, f32 nearZ, f32 farZ)
+{
+    CPolarSubCamera *cam = gpCamera;
+    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleInc(reinterpret_cast<f32 *>(cam)[0x48 / 4]);
+    C_MTXPerspective(mtx, fovY, aspect, nearZ, farZ);
+}
+SMS_PATCH_BL(SMS_PORT_REGION(0x8002322C,0x8002320C,0,0), scaleFOVYPerspectiveMatrix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x80025A04,0x800259E8,0,0), scaleFOVYPerspectiveMatrix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x80032D8C,0x80032D78,0,0), scaleFOVYPerspectiveMatrix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x80033088,0x80033074,0,0), scaleFOVYPerspectiveMatrix);
 
 static void scaleNintendoIntro(JUTRect *rect, int x1, int y1, int x2, int y2) {
     const f32 translate = getScreenRatioAdjustX();
@@ -581,7 +612,7 @@ SMS_PATCH_BL(SMS_PORT_REGION(0x8013F430, 0x80133FAC, 0, 0), patchLevelSelectPosi
 
 static void scaleUnderWaterMask(Mtx mtx, f32 x, f32 y, f32 z) {
     CPolarSubCamera *camera = gpCamera;
-    const f32 fovtangent = tan(angleToRadians(camera->mProjectionFovy * 0.5f)) * 2.0;
+    const f32 fovtangent = tanf(angleToRadians(camera->mProjectionFovy * 0.5f)) * 2.0;
     x *= fovtangent * getScreenToFullScreenRatio();
     y *= fovtangent;
     PSMTXScale(mtx, x, y, z);

--- a/src/patches/widescreen.cpp
+++ b/src/patches/widescreen.cpp
@@ -104,7 +104,7 @@ SMS_WRITE_32(SMS_PORT_REGION(0x802B8B9C, 0x802B0B6C, 0, 0), 0xEC010032);
 static void scaleFOVYPerspectiveMatrix(Mtx mtx, f32 fovY, f32 aspect, f32 nearZ, f32 farZ)
 {
     CPolarSubCamera *cam = gpCamera;
-    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleInc(fovY);
+    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleInc(cam->mProjectionFovy);
     C_MTXPerspective(mtx, fovY, aspect, nearZ, farZ);
 }
 SMS_PATCH_BL(SMS_PORT_REGION(0x8002322C,0x8002320C,0,0), scaleFOVYPerspectiveMatrix);
@@ -114,8 +114,7 @@ SMS_PATCH_BL(SMS_PORT_REGION(0x80033088,0x80033074,0,0), scaleFOVYPerspectiveMat
 
 static void scaleFOVYFix(CPolarSubCamera *cam)
 {
-    f32 fovY = reinterpret_cast<f32 *>(cam)[0x48 / 4];
-    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleDec(fovY);
+    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleDec(cam->mProjectionFovy);
     ctrlGameCamera___15CPolarSubCameraFv(cam);
 }
 SMS_PATCH_BL(SMS_PORT_REGION(0x80023148,0x80023120,0,0), scaleFOVYFix);

--- a/src/patches/widescreen.cpp
+++ b/src/patches/widescreen.cpp
@@ -101,23 +101,23 @@ SMS_WRITE_32(SMS_PORT_REGION(0x802B8B88, 0x802B0B58, 0, 0), 0xC8010AE0);
 SMS_WRITE_32(SMS_PORT_REGION(0x802B8B94, 0x802B0B64, 0, 0), 0xEC001028);
 SMS_WRITE_32(SMS_PORT_REGION(0x802B8B9C, 0x802B0B6C, 0, 0), 0xEC010032);
 
-static void scaleFOVYPerspectiveMatrix(Mtx mtx, f32 fovY, f32 aspect, f32 nearZ, f32 farZ)
+static void scaleFOVYIncreasePerspectiveMatrix(Mtx mtx, f32 fovY, f32 aspect, f32 nearZ, f32 farZ)
 {
     CPolarSubCamera *cam = gpCamera;
-    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleInc(cam->mProjectionFovy);
+    cam->mProjectionFovy = getRecalculatedFovyAngleInc(cam->mProjectionFovy);
     C_MTXPerspective(mtx, fovY, aspect, nearZ, farZ);
 }
-SMS_PATCH_BL(SMS_PORT_REGION(0x8002322C,0x8002320C,0,0), scaleFOVYPerspectiveMatrix);
-SMS_PATCH_BL(SMS_PORT_REGION(0x80025A04,0x800259E8,0,0), scaleFOVYPerspectiveMatrix);
-SMS_PATCH_BL(SMS_PORT_REGION(0x80032D8C,0x80032D78,0,0), scaleFOVYPerspectiveMatrix);
-SMS_PATCH_BL(SMS_PORT_REGION(0x80033088,0x80033074,0,0), scaleFOVYPerspectiveMatrix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x8002322C,0x8002320C,0,0), scaleFOVYIncreasePerspectiveMatrix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x80025A04,0x800259E8,0,0), scaleFOVYIncreasePerspectiveMatrix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x80032D8C,0x80032D78,0,0), scaleFOVYIncreasePerspectiveMatrix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x80033088,0x80033074,0,0), scaleFOVYIncreasePerspectiveMatrix);
 
-static void scaleFOVYFix(CPolarSubCamera *cam)
+static void scaleFOVYDecrease(CPolarSubCamera *cam)
 {
-    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleDec(cam->mProjectionFovy);
-    ctrlGameCamera___15CPolarSubCameraFv(cam);
+    cam->mProjectionFovy = getRecalculatedFovyAngleInc(cam->mProjectionFovy);
+    cam->ctrlGameCamera();
 }
-SMS_PATCH_BL(SMS_PORT_REGION(0x80023148,0x80023120,0,0), scaleFOVYFix);
+SMS_PATCH_BL(SMS_PORT_REGION(0x80023148,0x80023120,0,0), scaleFOVYDecrease);
 
 static void scaleNintendoIntro(JUTRect *rect, int x1, int y1, int x2, int y2) {
     const f32 translate = getScreenRatioAdjustX();

--- a/src/patches/widescreen.cpp
+++ b/src/patches/widescreen.cpp
@@ -581,8 +581,9 @@ SMS_PATCH_BL(SMS_PORT_REGION(0x8013F430, 0x80133FAC, 0, 0), patchLevelSelectPosi
 
 static void scaleUnderWaterMask(Mtx mtx, f32 x, f32 y, f32 z) {
     CPolarSubCamera *camera = gpCamera;
-    x *= camera->mProjectionFovy / 50.0f;
-    x *= getScreenToFullScreenRatio();
+    const f32 fovtangent = tan(angleToRadians(camera->mProjectionFovy * 0.5f)) * 2.0;
+    x *= fovtangent * getScreenToFullScreenRatio();
+    y *= fovtangent;
     PSMTXScale(mtx, x, y, z);
 }
 SMS_PATCH_BL(SMS_PORT_REGION(0x801ea96c, 0x801E2844, 0, 0), scaleUnderWaterMask);

--- a/src/patches/widescreen.cpp
+++ b/src/patches/widescreen.cpp
@@ -112,6 +112,14 @@ SMS_PATCH_BL(SMS_PORT_REGION(0x80025A04,0x800259E8,0,0), scaleFOVYPerspectiveMat
 SMS_PATCH_BL(SMS_PORT_REGION(0x80032D8C,0x80032D78,0,0), scaleFOVYPerspectiveMatrix);
 SMS_PATCH_BL(SMS_PORT_REGION(0x80033088,0x80033074,0,0), scaleFOVYPerspectiveMatrix);
 
+static void scaleFOVYFix(CPolarSubCamera *cam)
+{
+    f32 fovY = reinterpret_cast<f32 *>(cam)[0x48 / 4];
+    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleDec(fovY);
+    ctrlGameCamera___15CPolarSubCameraFv(cam);
+}
+SMS_PATCH_BL(SMS_PORT_REGION(0x80023148,0x80023120,0,0), scaleFOVYFix);
+
 static void scaleNintendoIntro(JUTRect *rect, int x1, int y1, int x2, int y2) {
     const f32 translate = getScreenRatioAdjustX();
 

--- a/src/patches/widescreen.cpp
+++ b/src/patches/widescreen.cpp
@@ -104,7 +104,7 @@ SMS_WRITE_32(SMS_PORT_REGION(0x802B8B9C, 0x802B0B6C, 0, 0), 0xEC010032);
 static void scaleFOVYPerspectiveMatrix(Mtx mtx, f32 fovY, f32 aspect, f32 nearZ, f32 farZ)
 {
     CPolarSubCamera *cam = gpCamera;
-    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleInc(reinterpret_cast<f32 *>(cam)[0x48 / 4]);
+    reinterpret_cast<f32 *>(cam)[0x48 / 4] = getRecalculatedFovyAngleInc(fovY);
     C_MTXPerspective(mtx, fovY, aspect, nearZ, farZ);
 }
 SMS_PATCH_BL(SMS_PORT_REGION(0x8002322C,0x8002320C,0,0), scaleFOVYPerspectiveMatrix);


### PR DESCRIPTION
To scale screens like this properly, a tangent from the fov angle is best for scaling, than in it's original degrees.