### PR TITLE
MarioModokiTesela_fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         "include/BetterSMS/objects/*.hxx"
     )
 
-    add_executable(BetterSunshineEngine ${BETTERSMS_SRC} "src/patches/modokiTeselafix.cpp")
+    add_executable(BetterSunshineEngine ${BETTERSMS_SRC})
     target_link_libraries(BetterSunshineEngine PUBLIC
                           Dolphin
                           JSystem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         "include/BetterSMS/objects/*.hxx"
     )
 
-    add_executable(BetterSunshineEngine ${BETTERSMS_SRC})
+    add_executable(BetterSunshineEngine ${BETTERSMS_SRC} "src/patches/modokiTeselafix.cpp")
     target_link_libraries(BetterSunshineEngine PUBLIC
                           Dolphin
                           JSystem

--- a/src/patches/modokiTeselafix.cpp
+++ b/src/patches/modokiTeselafix.cpp
@@ -1,0 +1,4 @@
+#include "module.hxx"
+
+// ignores a flag test that would usually only be true on git
+SMS_WRITE_32(SMS_PORT_REGION(0x80083ffc, 0, 0, 0), 0x60000000);

--- a/src/patches/modokiTeselafix.cpp
+++ b/src/patches/modokiTeselafix.cpp
@@ -1,5 +1,0 @@
-#include "module.hxx"
-
-
-//ignores a flag test that would usually only be true on git
-SMS_WRITE_32(SMS_PORT_REGION(0x80083ffc, 0, 0, 0), 0x60000000);

--- a/src/patches/modokiTeselafix.cpp
+++ b/src/patches/modokiTeselafix.cpp
@@ -1,0 +1,5 @@
+#include "module.hxx"
+
+
+//ignores a flag test that would usually only be true on git
+SMS_WRITE_32(SMS_PORT_REGION(0x80083ffc, 0, 0, 0), 0x60000000);

--- a/src/patches/objectfix.cpp
+++ b/src/patches/objectfix.cpp
@@ -1,6 +1,5 @@
 #include "module.hxx"
 
-
 //"/scene/mapObj/mon_bri_rope.bti" Swingboard - All 3
 SMS_WRITE_32(SMS_PORT_REGION(0x801b7628, 0, 0, 0), 0x60000000);
 SMS_WRITE_32(SMS_PORT_REGION(0x801b760c, 0, 0, 0), 0x60000000);

--- a/src/patches/objectfix.cpp
+++ b/src/patches/objectfix.cpp
@@ -8,5 +8,3 @@ SMS_WRITE_32(SMS_PORT_REGION(0x801b7660, 0, 0, 0), 0x60000000);
 
 //"/scene/mapObj/cogwheel_rope.bti"
 SMS_WRITE_32(SMS_PORT_REGION(0x801b7644, 0, 0, 0), 0x60000000);
-
-

--- a/src/patches/objectfix.cpp
+++ b/src/patches/objectfix.cpp
@@ -8,3 +8,5 @@ SMS_WRITE_32(SMS_PORT_REGION(0x801b7660, 0, 0, 0), 0x60000000);
 
 //"/scene/mapObj/cogwheel_rope.bti"
 SMS_WRITE_32(SMS_PORT_REGION(0x801b7644, 0, 0, 0), 0x60000000);
+
+


### PR DESCRIPTION
A fix for the fact that the fake shadow Mario (MarioModokiTesela) can be spawned on all stages and not just inside hotel delfino.