### PR TITLE
Export existing object functions

### DIFF
--- a/src/module.cpp
+++ b/src/module.cpp
@@ -521,6 +521,12 @@ KURIBO_MODULE_BEGIN(BETTER_SMS_MODULE_NAME, BETTER_SMS_AUTHOR_NAME, BETTER_SMS_V
                          "registerObjectAsMisc__Q29BetterSMS7ObjectsFPCcPFv_PQ26JDrama8TNameRef");
         KURIBO_EXPORT_AS(BetterSMS::Objects::getRemainingCapacity,
                          "getRemainingCapacity__Q29BetterSMS7ObjectsFv");
+        KURIBO_EXPORT_AS(
+            BetterSMS::Objects::registerObjectCollideInteractor,
+            "registerObjectCollideInteractor__Q29BetterSMS7ObjectsFUlPFP9THitActorP6TMario_v");
+        KURIBO_EXPORT_AS(
+            BetterSMS::Objects::registerObjectGrabInteractor,
+            "registerObjectGrabInteractor__Q29BetterSMS7ObjectsFUlPFP9THitActorP6TMario_v");
 #endif
 
         /* GAME */


### PR DESCRIPTION
These two functions were already implemented in BetterSMS::Objects. I have verified their functionality, and am exporting them so that they can be used in BSE modules. If there is a reason they were not exported, feel free to close this PR. I kept them in the BETTER_SMS_EXTRA_OBJECTS preprocessor block for consistency with the function definitions, but these two could likely live outside that as they don't necessarily pertain to extra objects. 