### PR TITLE
Allow animated materials on Mario instance

### DIFF
--- a/include/BetterSMS/player.hxx
+++ b/include/BetterSMS/player.hxx
@@ -239,7 +239,7 @@ namespace BetterSMS {
             TMario::TDirtyParams mDefaultDirtyParams;
 
             MActorAnmData* mMActorAnmData;
-            MActor* mMActor;
+            MActor* mMActor[10];
 
             TVec3f mWarpDestination;
             s32 mWarpTimer;

--- a/include/BetterSMS/player.hxx
+++ b/include/BetterSMS/player.hxx
@@ -93,7 +93,10 @@ namespace BetterSMS {
                   SMS_TPARAM_INIT(mPlayerHasShirt, false),
                   SMS_TPARAM_INIT(mThrowPowerMultiplier, 1.0f),
                   SMS_TPARAM_INIT(mUnderwaterHealthMultiplier, 1.0f),
-                  SMS_TPARAM_INIT(mFallDamageMinMultiplier, 1.0f) {
+                  SMS_TPARAM_INIT(mFallDamageMinMultiplier, 1.0f),
+                  SMS_TPARAM_INIT(mHasMActor, false),
+                  SMS_TPARAM_INIT(mMActorFramerate, 1.0f),
+                  SMS_TPARAM_INIT(mHasScreenTexture, false) {
                 load("/Mario/better_sms.prm");
             }
 
@@ -108,6 +111,9 @@ namespace BetterSMS {
             TParamRT<f32> mThrowPowerMultiplier;
             TParamRT<f32> mUnderwaterHealthMultiplier;
             TParamRT<f32> mFallDamageMinMultiplier;
+            TParamRT<bool> mHasMActor;
+            TParamRT<f32> mMActorFramerate;
+            TParamRT<bool> mHasScreenTexture;
         };
 
         class TPlayerData {
@@ -231,6 +237,9 @@ namespace BetterSMS {
             FluddHistory mFluddHistory;
             ParamHistory mDefaultAttrs;
             TMario::TDirtyParams mDefaultDirtyParams;
+
+            MActorAnmData* mMActorAnmData;
+            MActor* mMActor;
 
             TVec3f mWarpDestination;
             s32 mWarpTimer;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2,8 +2,8 @@
 #include <Dolphin/OS.h>
 
 #include <JSystem/J2D/J2DPrint.hxx>
-#include <JSystem/JKernel/JKRFileLoader.hxx>
 #include <JSystem/J3D/J3DModelLoaderDataBase.hxx>
+#include <JSystem/JKernel/JKRFileLoader.hxx>
 #include <SMS/Enemy/EffectObjBase.hxx>
 #include <SMS/GC2D/ConsoleStr.hxx>
 #include <SMS/MSound/MSoundSESystem.hxx>
@@ -380,11 +380,11 @@ BETTER_SMS_FOR_EXPORT void BetterSMS::Player::warpToCollisionFace(TMario *player
     triFluidCenter.y += 300.0f;
 
 #define EXPAND_WARP_SET(base)                                                                      \
-    (base) : case ((base) + 10):                                                                   \
+    (base) : case ((base) + 10) :                                                                  \
     case ((base) + 20):                                                                            \
     case ((base) + 30)
 #define EXPAND_WARP_CATEGORY(base)                                                                 \
-    (base) : case ((base) + 1):                                                                    \
+    (base) : case ((base) + 1) :                                                                   \
     case ((base) + 2):                                                                             \
     case ((base) + 3):                                                                             \
     case ((base) + 4)
@@ -693,52 +693,53 @@ static void initFludd(TMario *player, Player::TPlayerData *playerData) {
                                         ->mEmitParams.mAmountMax.get();
 }
 
-MActor* createMActorForModel(MActorAnmData* anmData, J3DModel* model, f32 configuredFramerate, const char* modelName) {
-    MActor* actor = new MActor(anmData);
+MActor *createMActorForModel(MActorAnmData *anmData, J3DModel *model, f32 configuredFramerate,
+                             const char *modelName) {
+    MActor *actor = new MActor(anmData);
     actor->setModel(model, 0);
     f32 framerate = configuredFramerate * SMSGetAnmFrameRate();
 
     // TODO: Allow finder grained control of these animations probably?
-    if(actor->checkAnmFileExist(modelName, MActor::BCK)) {
+    if (actor->checkAnmFileExist(modelName, MActor::BCK)) {
         actor->setBck(modelName);
-	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BCK);
-	    ctrl->mFrameRate = framerate;
-	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+        J3DFrameCtrl *ctrl = actor->getFrameCtrl(MActor::BCK);
+        ctrl->mFrameRate   = framerate;
+        ctrl->mAnimState   = J3DFrameCtrl::LOOP;
     }
 
-    if(actor->checkAnmFileExist(modelName, MActor::BLK)) {
+    if (actor->checkAnmFileExist(modelName, MActor::BLK)) {
         actor->setBlk(modelName);
-	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BLK);
-	    ctrl->mFrameRate = framerate;
-	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+        J3DFrameCtrl *ctrl = actor->getFrameCtrl(MActor::BLK);
+        ctrl->mFrameRate   = framerate;
+        ctrl->mAnimState   = J3DFrameCtrl::LOOP;
     }
 
-    if(actor->checkAnmFileExist(modelName, MActor::BRK)) {
+    if (actor->checkAnmFileExist(modelName, MActor::BRK)) {
         actor->setBrk(modelName);
-	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BRK);
-	    ctrl->mFrameRate = framerate;
-	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+        J3DFrameCtrl *ctrl = actor->getFrameCtrl(MActor::BRK);
+        ctrl->mFrameRate   = framerate;
+        ctrl->mAnimState   = J3DFrameCtrl::LOOP;
     }
 
-    if(actor->checkAnmFileExist(modelName, MActor::BPK)) {
+    if (actor->checkAnmFileExist(modelName, MActor::BPK)) {
         actor->setBpk(modelName);
-	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BPK);
-	    ctrl->mFrameRate = framerate;
-	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+        J3DFrameCtrl *ctrl = actor->getFrameCtrl(MActor::BPK);
+        ctrl->mFrameRate   = framerate;
+        ctrl->mAnimState   = J3DFrameCtrl::LOOP;
     }
 
-    if(actor->checkAnmFileExist(modelName, MActor::BTP)) {
+    if (actor->checkAnmFileExist(modelName, MActor::BTP)) {
         actor->setBtp(modelName);
-	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BTP);
-	    ctrl->mFrameRate = framerate;
-	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+        J3DFrameCtrl *ctrl = actor->getFrameCtrl(MActor::BTP);
+        ctrl->mFrameRate   = framerate;
+        ctrl->mAnimState   = J3DFrameCtrl::LOOP;
     }
 
-    if(actor->checkAnmFileExist(modelName, MActor::BTK)) {
+    if (actor->checkAnmFileExist(modelName, MActor::BTK)) {
         actor->setBtk(modelName);
-	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BTK);
-	    ctrl->mFrameRate = framerate;
-	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+        J3DFrameCtrl *ctrl = actor->getFrameCtrl(MActor::BTK);
+        ctrl->mFrameRate   = framerate;
+        ctrl->mAnimState   = J3DFrameCtrl::LOOP;
     }
 
     return actor;
@@ -775,40 +776,62 @@ BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
         isGlasses                         = params->getParams()->mPlayerHasGlasses.get();
 
         // Init MActor
-        if(params->getParams()->mHasMActor.get()) {
+        if (params->getParams()->mHasMActor.get()) {
             params->mMActorAnmData = new MActorAnmData();
-            JKRArcFinder *finder = JKRFileLoader::findFirstFile("/mario/custom");
-            if(finder != nullptr) {
+            JKRArcFinder *finder   = JKRFileLoader::findFirstFile("/mario/custom");
+            if (finder != nullptr) {
                 params->mMActorAnmData->init("mario/custom", nullptr);
-                auto* anmData = params->mMActorAnmData;
+                auto *anmData = params->mMActorAnmData;
                 f32 framerate = params->getParams()->mMActorFramerate.get();
-                params->mMActor[0] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_mdl1");
-                params->mMActor[1] = createMActorForModel(anmData, player->mHandModel2R, framerate, "ma_hnd2r");
-                params->mMActor[2] = createMActorForModel(anmData, player->mHandModel2L, framerate, "ma_hnd2l");
-                params->mMActor[3] = createMActorForModel(anmData, player->mHandModel3R, framerate, "ma_hnd3r");
-                params->mMActor[4] = createMActorForModel(anmData, player->mHandModel3L, framerate, "ma_hnd3l");
-                params->mMActor[5] = createMActorForModel(anmData, player->mHandModel4R, framerate, "ma_hnd4r");
-                params->mMActor[6] = createMActorForModel(anmData, player->mCap->mCap1, framerate, "ma_cap1");
-                params->mMActor[7] = createMActorForModel(anmData, player->mCap->mCap3, framerate, "ma_cap3");
-                params->mMActor[8] = createMActorForModel(anmData, player->mCap->mDiverHelm, framerate, "diver_helm");
-                params->mMActor[9] = createMActorForModel(anmData, player->mCap->maGlass1, framerate, "ma_glass1");
+                params->mMActor[0] =
+                    createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_mdl1");
+                params->mMActor[1] =
+                    createMActorForModel(anmData, player->mHandModel2R, framerate, "ma_hnd2r");
+                params->mMActor[2] =
+                    createMActorForModel(anmData, player->mHandModel2L, framerate, "ma_hnd2l");
+                params->mMActor[3] =
+                    createMActorForModel(anmData, player->mHandModel3R, framerate, "ma_hnd3r");
+                params->mMActor[4] =
+                    createMActorForModel(anmData, player->mHandModel3L, framerate, "ma_hnd3l");
+                params->mMActor[5] =
+                    createMActorForModel(anmData, player->mHandModel4R, framerate, "ma_hnd4r");
+                params->mMActor[6] =
+                    createMActorForModel(anmData, player->mCap->mCap1, framerate, "ma_cap1");
+                params->mMActor[7] =
+                    createMActorForModel(anmData, player->mCap->mCap3, framerate, "ma_cap3");
+                params->mMActor[8] = createMActorForModel(anmData, player->mCap->mDiverHelm,
+                                                          framerate, "diver_helm");
+                params->mMActor[9] =
+                    createMActorForModel(anmData, player->mCap->maGlass1, framerate, "ma_glass1");
 
             } else {
-                OSReport("Missing /custom folder in mario model. Skipping initialization of MActor\n");
+                OSReport(
+                    "Missing /custom folder in mario model. Skipping initialization of MActor\n");
             }
         }
-        if(params->getParams()->mHasScreenTexture.get()) {
-            // Replaces dummy placeholder with screen texture. Necessary for e.g Shadow mario to work TODO: Standardize this?
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mBodyModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel2R->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel2L->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel3R->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel3L->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel4R->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mCap1->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mCap3->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mDiverHelm->mModelData, "H_kagemario_dummy");
-			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->maGlass1->mModelData, "H_kagemario_dummy");
+        if (params->getParams()->mHasScreenTexture.get()) {
+            // Replaces dummy placeholder with screen texture. Necessary for e.g Shadow mario to
+            // work TODO: Standardize this?
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mBodyModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mHandModel2R->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mHandModel2L->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mHandModel3R->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mHandModel3L->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mHandModel4R->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mCap->mCap1->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mCap->mCap3->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mCap->mDiverHelm->mModelData, "H_kagemario_dummy");
+            replace__14TScreenTextureFP12J3DModelDataPCc(
+                *(u32 **)0x8040e0bc, player->mCap->maGlass1->mModelData, "H_kagemario_dummy");
         }
 
         initFludd(player, params);
@@ -880,11 +903,11 @@ static void playerUpdateHandler(TMario *player, JDrama::TGraphics *graphics) {
         item(player, true);
     }
 
-    auto* params = Player::getData(player);
+    auto *params = Player::getData(player);
 
-    for(int i = 0; i < 10; ++i) {
-        MActor* mActor = params->mMActor[i];
-        if(mActor != nullptr) {
+    for (int i = 0; i < 10; ++i) {
+        MActor *mActor = params->mMActor[i];
+        if (mActor != nullptr) {
             mActor->frameUpdate();
         }
     }
@@ -894,18 +917,18 @@ static void playerUpdateHandler(TMario *player, JDrama::TGraphics *graphics) {
 SMS_PATCH_BL(SMS_PORT_REGION(0x8024D3A0, 0x80245134, 0, 0), playerUpdateHandler);  // Mario
 
 static void playerDrawHandler(TMario *player, JDrama::TGraphics *graphics) {
-    auto* params = Player::getData(player);
-    if(params->mMActor[0]) {
-        for(int i = 0; i < 10; ++i) {
-            MActor* mActor = params->mMActor[i];
-            if(mActor != nullptr) {
+    auto *params = Player::getData(player);
+    if (params->mMActor[0]) {
+        for (int i = 0; i < 10; ++i) {
+            MActor *mActor = params->mMActor[i];
+            if (mActor != nullptr) {
                 mActor->entryIn();
             }
         }
         player->entryModels(graphics);
-        for(int i = 0; i < 10; ++i) {
-            MActor* mActor = params->mMActor[i];
-            if(mActor != nullptr) {
+        for (int i = 0; i < 10; ++i) {
+            MActor *mActor = params->mMActor[i];
+            if (mActor != nullptr) {
                 mActor->entryOut();
             }
         }
@@ -915,18 +938,17 @@ static void playerDrawHandler(TMario *player, JDrama::TGraphics *graphics) {
 }
 SMS_PATCH_BL(SMS_PORT_REGION(0x8024d6d0, 0, 0, 0), playerDrawHandler);  // Mario
 
-
 // Allow animated texture for Mario
-SMS_WRITE_32(SMS_PORT_REGION(0x802465e8, 0, 0, 0), 0x3c801130); // ma_mdl1
-SMS_WRITE_32(SMS_PORT_REGION(0x80246744, 0, 0, 0), 0x3c801130); // ma_hnd2r
-SMS_WRITE_32(SMS_PORT_REGION(0x80246754, 0, 0, 0), 0x3c801130); // ma_hnd2l
-SMS_WRITE_32(SMS_PORT_REGION(0x80246764, 0, 0, 0), 0x3c801130); // ma_hnd3r
-SMS_WRITE_32(SMS_PORT_REGION(0x80246774, 0, 0, 0), 0x3c801130); // ma_hnd3l
-SMS_WRITE_32(SMS_PORT_REGION(0x80246784, 0, 0, 0), 0x3c801130); // ma_hnd4r
-SMS_WRITE_32(SMS_PORT_REGION(0x802421bc, 0, 0, 0), 0x3c801130); // ma_cap1
-SMS_WRITE_32(SMS_PORT_REGION(0x80242290, 0, 0, 0), 0x3c801130); // ma_cap3
-SMS_WRITE_32(SMS_PORT_REGION(0x802423b4, 0, 0, 0), 0x3c801130); // diver_helm
-SMS_WRITE_32(SMS_PORT_REGION(0x802423f0, 0, 0, 0), 0x3c801130); // ma_glass1
+SMS_WRITE_32(SMS_PORT_REGION(0x802465e8, 0, 0, 0), 0x3c801130);  // ma_mdl1
+SMS_WRITE_32(SMS_PORT_REGION(0x80246744, 0, 0, 0), 0x3c801130);  // ma_hnd2r
+SMS_WRITE_32(SMS_PORT_REGION(0x80246754, 0, 0, 0), 0x3c801130);  // ma_hnd2l
+SMS_WRITE_32(SMS_PORT_REGION(0x80246764, 0, 0, 0), 0x3c801130);  // ma_hnd3r
+SMS_WRITE_32(SMS_PORT_REGION(0x80246774, 0, 0, 0), 0x3c801130);  // ma_hnd3l
+SMS_WRITE_32(SMS_PORT_REGION(0x80246784, 0, 0, 0), 0x3c801130);  // ma_hnd4r
+SMS_WRITE_32(SMS_PORT_REGION(0x802421bc, 0, 0, 0), 0x3c801130);  // ma_cap1
+SMS_WRITE_32(SMS_PORT_REGION(0x80242290, 0, 0, 0), 0x3c801130);  // ma_cap3
+SMS_WRITE_32(SMS_PORT_REGION(0x802423b4, 0, 0, 0), 0x3c801130);  // diver_helm
+SMS_WRITE_32(SMS_PORT_REGION(0x802423f0, 0, 0, 0), 0x3c801130);  // ma_glass1
 
 // Disable Lock in SMS_MakeDLAndLock
 // This breaks mActor initialization causing animations to not be applied properly

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -878,7 +878,16 @@ SMS_PATCH_BL(SMS_PORT_REGION(0x8024d6d0, 0, 0, 0), playerDrawHandler);  // Mario
 
 
 // Allow animated texture for Mario
-SMS_WRITE_32(SMS_PORT_REGION(0x802465e8, 0, 0, 0), 0x3c801130);
+SMS_WRITE_32(SMS_PORT_REGION(0x802465e8, 0, 0, 0), 0x3c801130); // ma_mdl1
+SMS_WRITE_32(SMS_PORT_REGION(0x80246744, 0, 0, 0), 0x3c801130); // ma_hnd2r
+SMS_WRITE_32(SMS_PORT_REGION(0x80246754, 0, 0, 0), 0x3c801130); // ma_hnd2lr
+SMS_WRITE_32(SMS_PORT_REGION(0x80246764, 0, 0, 0), 0x3c801130); // ma_hnd3r
+SMS_WRITE_32(SMS_PORT_REGION(0x80246774, 0, 0, 0), 0x3c801130); // ma_hnd3lr
+SMS_WRITE_32(SMS_PORT_REGION(0x80246784, 0, 0, 0), 0x3c801130); // ma_hnd4r
+SMS_WRITE_32(SMS_PORT_REGION(0x802421bc, 0, 0, 0), 0x3c801130); // ma_cap1
+SMS_WRITE_32(SMS_PORT_REGION(0x80242290, 0, 0, 0), 0x3c801130); // ma_cap3
+SMS_WRITE_32(SMS_PORT_REGION(0x802423b4, 0, 0, 0), 0x3c801130); // diver_helm
+SMS_WRITE_32(SMS_PORT_REGION(0x802423f0, 0, 0, 0), 0x3c801130); // ma_glass1
 
 // Disable Lock in SMS_MakeDLAndLock
 // This breaks mActor initialization causing animations to not be applied properly

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -693,6 +693,57 @@ static void initFludd(TMario *player, Player::TPlayerData *playerData) {
                                         ->mEmitParams.mAmountMax.get();
 }
 
+MActor* createMActorForModel(MActorAnmData* anmData, J3DModel* model, f32 configuredFramerate, const char* modelName) {
+    MActor* actor = new MActor(anmData);
+    actor->setModel(model, 0);
+    f32 framerate = configuredFramerate * SMSGetAnmFrameRate();
+
+    // TODO: Allow finder grained control of these animations probably?
+    if(actor->checkAnmFileExist(modelName, MActor::BCK)) {
+        actor->setBck(modelName);
+	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BCK);
+	    ctrl->mFrameRate = framerate;
+	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+    }
+
+    if(actor->checkAnmFileExist(modelName, MActor::BLK)) {
+        actor->setBlk(modelName);
+	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BLK);
+	    ctrl->mFrameRate = framerate;
+	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+    }
+
+    if(actor->checkAnmFileExist(modelName, MActor::BRK)) {
+        actor->setBrk(modelName);
+	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BRK);
+	    ctrl->mFrameRate = framerate;
+	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+    }
+
+    if(actor->checkAnmFileExist(modelName, MActor::BPK)) {
+        actor->setBpk(modelName);
+	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BPK);
+	    ctrl->mFrameRate = framerate;
+	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+    }
+
+    if(actor->checkAnmFileExist(modelName, MActor::BTP)) {
+        actor->setBtp(modelName);
+	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BTP);
+	    ctrl->mFrameRate = framerate;
+	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+    }
+
+    if(actor->checkAnmFileExist(modelName, MActor::BTK)) {
+        actor->setBtk(modelName);
+	    J3DFrameCtrl* ctrl = actor->getFrameCtrl(MActor::BTK);
+	    ctrl->mFrameRate = framerate;
+	    ctrl->mAnimState = J3DFrameCtrl::LOOP;
+    }
+
+    return actor;
+}
+
 // Extern to Player Init CB
 BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
     Stage::TStageParams *config = Stage::getStageConfiguration();
@@ -729,53 +780,19 @@ BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
             JKRArcFinder *finder = JKRFileLoader::findFirstFile("/mario/custom");
             if(finder != 0x0) {
                 params->mMActorAnmData->init("mario/custom", nullptr);
-                params->mMActor = new MActor(params->mMActorAnmData);
-                params->mMActor->setModel(player->mModelData->mModel, 0);
+                auto* anmData = params->mMActorAnmData;
+                f32 framerate = params->getParams()->mMActorFramerate.get();
+                params->mMActor[0] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_mdl1");
+                params->mMActor[1] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd2r");
+                params->mMActor[2] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd2lr");
+                params->mMActor[3] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd3r");
+                params->mMActor[4] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd3lr");
+                params->mMActor[5] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd4r");
+                params->mMActor[6] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_cap1");
+                params->mMActor[7] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_cap3");
+                params->mMActor[8] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "diver_helm");
+                params->mMActor[9] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_glass1");
 
-			    f32 framerate = params->getParams()->mMActorFramerate.get() * SMSGetAnmFrameRate();
-
-                // TODO: Allow finder grained control of these animations probably?
-                if(params->mMActor->checkAnmFileExist("default", MActor::BCK)) {
-                    params->mMActor->setBck("default");
-				    J3DFrameCtrl* ctrl = params->mMActor->getFrameCtrl(MActor::BCK);
-				    ctrl->mFrameRate = framerate;
-				    ctrl->mAnimState = J3DFrameCtrl::LOOP;
-                }
-
-                if(params->mMActor->checkAnmFileExist("default", MActor::BLK)) {
-                    params->mMActor->setBlk("default");
-				    J3DFrameCtrl* ctrl = params->mMActor->getFrameCtrl(MActor::BLK);
-				    ctrl->mFrameRate = framerate;
-				    ctrl->mAnimState = J3DFrameCtrl::LOOP;
-                }
-
-                if(params->mMActor->checkAnmFileExist("default", MActor::BRK)) {
-                    params->mMActor->setBrk("default");
-				    J3DFrameCtrl* ctrl = params->mMActor->getFrameCtrl(MActor::BRK);
-				    ctrl->mFrameRate = framerate;
-				    ctrl->mAnimState = J3DFrameCtrl::LOOP;
-                }
-
-                if(params->mMActor->checkAnmFileExist("default", MActor::BPK)) {
-                    params->mMActor->setBpk("default");
-				    J3DFrameCtrl* ctrl = params->mMActor->getFrameCtrl(MActor::BPK);
-				    ctrl->mFrameRate = framerate;
-				    ctrl->mAnimState = J3DFrameCtrl::LOOP;
-                }
-
-                if(params->mMActor->checkAnmFileExist("default", MActor::BTP)) {
-                    params->mMActor->setBtp("default");
-				    J3DFrameCtrl* ctrl = params->mMActor->getFrameCtrl(MActor::BTP);
-				    ctrl->mFrameRate = framerate;
-				    ctrl->mAnimState = J3DFrameCtrl::LOOP;
-                }
-
-                if(params->mMActor->checkAnmFileExist("default", MActor::BTK)) {
-                    params->mMActor->setBtk("default");
-				    J3DFrameCtrl* ctrl = params->mMActor->getFrameCtrl(MActor::BTK);
-				    ctrl->mFrameRate = framerate;
-				    ctrl->mAnimState = J3DFrameCtrl::LOOP;
-                }
             } else {
                 OSReport("Missing /custom folder in mario model. Skipping initialization of MActor\n");
             }
@@ -856,8 +873,10 @@ static void playerUpdateHandler(TMario *player, JDrama::TGraphics *graphics) {
 
     auto* params = Player::getData(player);
 
-    if(params->mMActor) {
-        params->mMActor->frameUpdate();
+    if(params->mMActor[0]) {
+        for(int i = 0; i < 10; ++i) {
+            params->mMActor[i]->frameUpdate();
+        }
     }
 
     player->playerControl(graphics);
@@ -866,10 +885,14 @@ SMS_PATCH_BL(SMS_PORT_REGION(0x8024D3A0, 0x80245134, 0, 0), playerUpdateHandler)
 
 static void playerDrawHandler(TMario *player, JDrama::TGraphics *graphics) {
     auto* params = Player::getData(player);
-    if(params->mMActor) {
-        params->mMActor->entryIn();
+    if(params->mMActor[0]) {
+        for(int i = 0; i < 10; ++i) {
+            params->mMActor[i]->entryIn();
+        }
         player->entryModels(graphics);
-        params->mMActor->entryOut();
+        for(int i = 0; i < 10; ++i) {
+            params->mMActor[i]->entryOut();
+        }
     } else {
         player->entryModels(graphics);
     }

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -784,9 +784,9 @@ BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
                 f32 framerate = params->getParams()->mMActorFramerate.get();
                 params->mMActor[0] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_mdl1");
                 params->mMActor[1] = createMActorForModel(anmData, player->mHandModel2R, framerate, "ma_hnd2r");
-                params->mMActor[2] = createMActorForModel(anmData, player->mHandModel2L, framerate, "ma_hnd2lr");
+                params->mMActor[2] = createMActorForModel(anmData, player->mHandModel2L, framerate, "ma_hnd2l");
                 params->mMActor[3] = createMActorForModel(anmData, player->mHandModel3R, framerate, "ma_hnd3r");
-                params->mMActor[4] = createMActorForModel(anmData, player->mHandModel3L, framerate, "ma_hnd3lr");
+                params->mMActor[4] = createMActorForModel(anmData, player->mHandModel3L, framerate, "ma_hnd3l");
                 params->mMActor[5] = createMActorForModel(anmData, player->mHandModel4R, framerate, "ma_hnd4r");
                 params->mMActor[6] = createMActorForModel(anmData, player->mCap->mCap1, framerate, "ma_cap1");
                 params->mMActor[7] = createMActorForModel(anmData, player->mCap->mCap3, framerate, "ma_cap3");
@@ -800,6 +800,11 @@ BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
         if(params->getParams()->mHasScreenTexture.get()) {
             // Replaces dummy placeholder with screen texture. Necessary for e.g Shadow mario to work TODO: Standardize this?
 			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mBodyModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel2R->mModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel2L->mModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel3R->mModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel3L->mModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mHandModel4R->mModelData, "H_kagemario_dummy");
 			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mCap1->mModelData, "H_kagemario_dummy");
 			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mCap3->mModelData, "H_kagemario_dummy");
 			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mDiverHelm->mModelData, "H_kagemario_dummy");
@@ -907,9 +912,9 @@ SMS_PATCH_BL(SMS_PORT_REGION(0x8024d6d0, 0, 0, 0), playerDrawHandler);  // Mario
 // Allow animated texture for Mario
 SMS_WRITE_32(SMS_PORT_REGION(0x802465e8, 0, 0, 0), 0x3c801130); // ma_mdl1
 SMS_WRITE_32(SMS_PORT_REGION(0x80246744, 0, 0, 0), 0x3c801130); // ma_hnd2r
-SMS_WRITE_32(SMS_PORT_REGION(0x80246754, 0, 0, 0), 0x3c801130); // ma_hnd2lr
+SMS_WRITE_32(SMS_PORT_REGION(0x80246754, 0, 0, 0), 0x3c801130); // ma_hnd2l
 SMS_WRITE_32(SMS_PORT_REGION(0x80246764, 0, 0, 0), 0x3c801130); // ma_hnd3r
-SMS_WRITE_32(SMS_PORT_REGION(0x80246774, 0, 0, 0), 0x3c801130); // ma_hnd3lr
+SMS_WRITE_32(SMS_PORT_REGION(0x80246774, 0, 0, 0), 0x3c801130); // ma_hnd3l
 SMS_WRITE_32(SMS_PORT_REGION(0x80246784, 0, 0, 0), 0x3c801130); // ma_hnd4r
 SMS_WRITE_32(SMS_PORT_REGION(0x802421bc, 0, 0, 0), 0x3c801130); // ma_cap1
 SMS_WRITE_32(SMS_PORT_REGION(0x80242290, 0, 0, 0), 0x3c801130); // ma_cap3

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -783,15 +783,15 @@ BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
                 auto* anmData = params->mMActorAnmData;
                 f32 framerate = params->getParams()->mMActorFramerate.get();
                 params->mMActor[0] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_mdl1");
-                params->mMActor[1] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd2r");
-                params->mMActor[2] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd2lr");
-                params->mMActor[3] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd3r");
-                params->mMActor[4] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd3lr");
-                params->mMActor[5] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_hnd4r");
-                params->mMActor[6] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_cap1");
-                params->mMActor[7] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_cap3");
-                params->mMActor[8] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "diver_helm");
-                params->mMActor[9] = createMActorForModel(anmData, player->mModelData->mModel, framerate, "ma_glass1");
+                params->mMActor[1] = createMActorForModel(anmData, player->mHandModel2R, framerate, "ma_hnd2r");
+                params->mMActor[2] = createMActorForModel(anmData, player->mHandModel2L, framerate, "ma_hnd2lr");
+                params->mMActor[3] = createMActorForModel(anmData, player->mHandModel3R, framerate, "ma_hnd3r");
+                params->mMActor[4] = createMActorForModel(anmData, player->mHandModel3L, framerate, "ma_hnd3lr");
+                params->mMActor[5] = createMActorForModel(anmData, player->mHandModel4R, framerate, "ma_hnd4r");
+                params->mMActor[6] = createMActorForModel(anmData, player->mCap->mCap1, framerate, "ma_cap1");
+                params->mMActor[7] = createMActorForModel(anmData, player->mCap->mCap3, framerate, "ma_cap3");
+                params->mMActor[8] = createMActorForModel(anmData, player->mCap->mDiverHelm, framerate, "diver_helm");
+                params->mMActor[9] = createMActorForModel(anmData, player->mCap->maGlass1, framerate, "ma_glass1");
 
             } else {
                 OSReport("Missing /custom folder in mario model. Skipping initialization of MActor\n");
@@ -800,6 +800,10 @@ BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
         if(params->getParams()->mHasScreenTexture.get()) {
             // Replaces dummy placeholder with screen texture. Necessary for e.g Shadow mario to work TODO: Standardize this?
 			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mBodyModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mCap1->mModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mCap3->mModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->mDiverHelm->mModelData, "H_kagemario_dummy");
+			replace__14TScreenTextureFP12J3DModelDataPCc(*(u32**)0x8040e0bc, player->mCap->maGlass1->mModelData, "H_kagemario_dummy");
         }
 
         initFludd(player, params);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -778,7 +778,7 @@ BETTER_SMS_FOR_CALLBACK void initMario(TMario *player, bool isMario) {
         if(params->getParams()->mHasMActor.get()) {
             params->mMActorAnmData = new MActorAnmData();
             JKRArcFinder *finder = JKRFileLoader::findFirstFile("/mario/custom");
-            if(finder != 0x0) {
+            if(finder != nullptr) {
                 params->mMActorAnmData->init("mario/custom", nullptr);
                 auto* anmData = params->mMActorAnmData;
                 f32 framerate = params->getParams()->mMActorFramerate.get();
@@ -882,9 +882,10 @@ static void playerUpdateHandler(TMario *player, JDrama::TGraphics *graphics) {
 
     auto* params = Player::getData(player);
 
-    if(params->mMActor[0]) {
-        for(int i = 0; i < 10; ++i) {
-            params->mMActor[i]->frameUpdate();
+    for(int i = 0; i < 10; ++i) {
+        MActor* mActor = params->mMActor[i];
+        if(mActor != nullptr) {
+            mActor->frameUpdate();
         }
     }
 
@@ -896,11 +897,17 @@ static void playerDrawHandler(TMario *player, JDrama::TGraphics *graphics) {
     auto* params = Player::getData(player);
     if(params->mMActor[0]) {
         for(int i = 0; i < 10; ++i) {
-            params->mMActor[i]->entryIn();
+            MActor* mActor = params->mMActor[i];
+            if(mActor != nullptr) {
+                mActor->entryIn();
+            }
         }
         player->entryModels(graphics);
         for(int i = 0; i < 10; ++i) {
-            params->mMActor[i]->entryOut();
+            MActor* mActor = params->mMActor[i];
+            if(mActor != nullptr) {
+                mActor->entryOut();
+            }
         }
     } else {
         player->entryModels(graphics);


### PR DESCRIPTION
This allows for e.g Shadow Mario to be created as a mario skin. With the inclusion of this you can add e.g btk animations to mario. It is all optinally feature toggled from the model and the original mario model works by default.

Currently i've added two prm paramters for this. One for adding a MActor to mario and another for replacing a specific material with the screen texture. (This is to support Shadow Mario, but can technically be used by other models as well)

I've attached some example skins that i've used to test this. 
[mario_skins.zip](https://github.com/user-attachments/files/17007312/mario_skins.zip)
